### PR TITLE
Fix paths to allow package to be installed (to $TEXMF[LOCAL|HOME])

### DIFF
--- a/jkureport.sty
+++ b/jkureport.sty
@@ -490,15 +490,30 @@
 \fi
 
 \ifbool{jkureport@xetexfonts}{%
+    \RequirePackage{fontspec}
+    % discover font path
     \expandafter\IfFileExists\expandafter{\jkureport@fontpath PublicSans-Regular.ttf}{%
+        \IfFontExistsTF{\jkureport@fontpath PublicSans-Regular.ttf}{%
+        }{%
+            \xdef\jkureport@fontpath{}
+        }%
     }{\expandafter\IfFileExists\expandafter{\jkureport@fontpath/PublicSans-Regular.ttf}{%
         \xdef\jkureport@fontpath{\jkureport@fontpath/}
+        \IfFontExistsTF{\jkureport@fontpath PublicSans-Regular.ttf}{%
         }{%
+            \xdef\jkureport@fontpath{}
+        }%
+    }{\IfFontExistsTF{PublicSans-Regular.ttf}{%
+        \xdef\jkureport@fontpath{}
+    }{%
         \PackageError{jkureport}{Font files not found in `\jkureport@fontpath', forgot to set the font path with package option `fontpath='?}{}%
         \stop
-    }}
-    
-    \RequirePackage{fontspec}
+    }}}%
+    \IfFontExistsTF{\jkureport@fontpath PublicSans-Regular.ttf}{%
+    }{%
+        \PackageError{jkureport}{Font files not found in local installation. Fonts must be installed to `$TEXMF[HOME|LOCAL]/fonts/truetype/' or an alternative font path set with package option `fontpath='}{}%
+        \stop
+    }%
     \defaultfontfeatures{
         Path={\jkureport@fontpath},
         Extension=.ttf,

--- a/jkureport.sty
+++ b/jkureport.sty
@@ -109,7 +109,7 @@
     logopath/.code={%
         \renewcommand{\jkureport@logopath}{#1}%
     },
-    logopath=./logos,
+    logopath=logos,
 }
 
 % Option fontpath={}: set path to template font resources (defaults to "./fonts")
@@ -120,7 +120,7 @@
     fontpath/.code={%
         \renewcommand{\jkureport@fontpath}{#1}%
     },
-    fontpath=./fonts,
+    fontpath=fonts,
 }
 
 % Option [no]fancyfonts: use custom TTF fonts with XeTeX (defaults to true)
@@ -493,7 +493,7 @@
     \expandafter\IfFileExists\expandafter{\jkureport@fontpath PublicSans-Regular.ttf}{%
     }{\expandafter\IfFileExists\expandafter{\jkureport@fontpath/PublicSans-Regular.ttf}{%
         \xdef\jkureport@fontpath{\jkureport@fontpath/}
-    }{%
+        }{%
         \PackageError{jkureport}{Font files not found in `\jkureport@fontpath', forgot to set the font path with package option `fontpath='?}{}%
         \stop
     }}


### PR DESCRIPTION
See #13 and https://github.com/michaelroland/jku-templates-presentation-latex/issues/3 

For images, the fix is to simply remove the leading "./" from the relative path. This permits LaTeX to search the whole \input@path (?!) instead of being just relative to the TeX document root.

For fonts, its a bit more complicated, since installed fonts are not located in the package installation directory but in a dedicated fonts directory ($TEXMF[LOCAL|HOME]/fonts/truetype/). When installing, the package, fonts need to be moved there (either directly or in subdirectories). This fix attempts to detect if fonts are installed into the appropriate location and tries to warn the user if fonts are found in the package directory.
