### PR TITLE
The name of the degree program was not shown on the title page.

### DIFF
--- a/jkureport.sty
+++ b/jkureport.sty
@@ -1729,6 +1729,7 @@
                 }{%
                 }}}}%
                 }\par%
+                \jkureport@insertdegreeprogram%
             }%
         }%
     }{%

--- a/jkureport.sty
+++ b/jkureport.sty
@@ -1729,7 +1729,7 @@
                 }{%
                 }}}}%
                 }\par%
-                \jkureport@insertdegreeprogram%
+                \jkureport@insertdegreeprogram\par%
             }%
         }%
     }{%


### PR DESCRIPTION
It would only output

> **Doctoral Thesis**
> to confer the academic degree of
> **Doktor der technischen Wissenschaften**
> in the Doctoral Program

instead of 

> **Doctoral Thesis**
> to confer the academic degree of
> **Doktor der technischen Wissenschaften**
> in the Doctoral Program
> **Technische Wissenschaften**
