### PR TITLE
fix for hyperxmp 5.12

### DIFF
--- a/jkureport.sty
+++ b/jkureport.sty
@@ -36,19 +36,24 @@
 \RequirePackage{amsmath}
 \RequirePackage{url}
 \RequirePackage{enumitem}
-\RequirePackage{hyperref}
-\RequirePackage{hyperxmp}
-\hypersetup{
+\RequirePackage[
     bookmarks=true,
-    bookmarksnumbered=false,
-    bookmarksopen=true,
+    %bookmarksnumbered=false,
+    %bookmarksopen=true,
     linkcolor={jkuPurple},
     urlcolor={jkuBlue},
     colorlinks=false,
+    unicode=true,
+    ]{hyperref}
+\RequirePackage{hyperxmp}
+\RequirePackage[
+    numbered=false,
+    open=true,
+    ]{bookmark}
+\hypersetup{
     pdfstartview=FitH,
     pdfpagelayout=OneColumn,
     pdfborder={0 0 0},
-    unicode=true,
     keeppdfinfo,
 }
 \RequirePackage{multirow}

--- a/jkureport.sty
+++ b/jkureport.sty
@@ -36,8 +36,9 @@
 \RequirePackage{amsmath}
 \RequirePackage{url}
 \RequirePackage{enumitem}
+\RequirePackage{hyperref}
 \RequirePackage{hyperxmp}
-\RequirePackage[
+\hypersetup{
     bookmarks=true,
     bookmarksnumbered=false,
     bookmarksopen=true,
@@ -49,7 +50,7 @@
     pdfborder={0 0 0},
     unicode=true,
     keeppdfinfo,
-    ]{hyperref}
+}
 \RequirePackage{multirow}
 \RequirePackage{array}
 \RequirePackage{tabularx}

--- a/jkureport.sty
+++ b/jkureport.sty
@@ -44,6 +44,7 @@
     urlcolor={jkuBlue},
     colorlinks=false,
     unicode=true,
+    pdfa,
     ]{hyperref}
 \RequirePackage{hyperxmp}
 \RequirePackage[


### PR DESCRIPTION
Change the loading to work on the newer hyperxmp version (5.12); should resolve author missing in xmp metadata:

"To use hyperxmp, merely put a \usepackage{hyperxmp} in your document’s preamble. That line can appear anywhere after the \usepackage{hyperref} but before hyperref’s pdf options are specified with \hypersetup. "