### PR TITLE
Improvements and fixes for mathastext

### DIFF
--- a/jkureport.sty
+++ b/jkureport.sty
@@ -695,7 +695,7 @@
 %% 
 
 \ifbool{jkureport@mathastext}{%
-    \usepackage[italic,defaultmathsizes,eulergreek,nosmalldelims]{mathastext}%
+    \usepackage[italic,defaultmathsizes,eulergreek,nosmalldelims,unicodeminus]{mathastext}
 }{}
 
 %% 

--- a/jkureport.sty
+++ b/jkureport.sty
@@ -695,6 +695,18 @@
 %% 
 
 \ifbool{jkureport@mathastext}{%
+    \ifxetex%
+        % As of version 1.4, mathastext no longer compiles with XeLaTeX unless we
+        % the (deprecated) everymath option or the nominus option. Bug has been
+        % acknowledged by mathastext author. Until then, we are safe to use everymath:
+        \PassOptionsToPackage{everymath}{mathastext}
+        % In the future, we may also want to consider to use nominus (and use the
+        % standard math font for it). In that case, we should do this for at least
+        % the three basic operators +/-/= to achieve consistent operator alignment.
+        % Actually, this looks very promising in combination with FiraMath and we
+        % might want to consider always doing that in future (not just for XeLaTeX):
+        %\PassOptionsToPackage{noplus,nominus,noequal}{mathastext}
+    \fi
     \usepackage[italic,defaultmathsizes,eulergreek,nosmalldelims,unicodeminus]{mathastext}
 }{}
 


### PR DESCRIPTION
- Improves alignment of minus symbol in relation to plus and equals operators
- Fixes compatibility with mathastext version 1.4b on XeLaTeX, see #20 