### PR TITLE
Print date in current language format if \date{YYYY-MM-DD} is given a…

### DIFF
--- a/jkureport.sty
+++ b/jkureport.sty
@@ -1965,10 +1965,15 @@
 \newcommand{\jkureport@insertsubmissiondate}{%
     \begingroup%
     \DTMsetstyle{iso}%
-    \edef\@tmp{\noexpand\DTMsavedate{submissiondate}{\@date}}\@tmp%
-    \DTMmonthname{\DTMfetchmonth{submissiondate}}~\DTMfetchyear{submissiondate}%
+    \edef\@tmp{\noexpand\DTMsavedate{jkureport@docdate}{\@date}}\@tmp%
+    \DTMmonthname{\DTMfetchmonth{jkureport@docdate}}~\DTMfetchyear{jkureport@docdate}%
     \endgroup%
 }
+\ExplSyntaxOn
+\NewDocumentCommand{\jkureport@ifisodate}{mmm}{
+	\regex_match:nnTF {\A\d{4}-?\d{2}-?\d{2}\Z} {#1} {#2} {#3}
+}
+\ExplSyntaxOff
 \newcommand{\jkureport@insertdate}{%
     \ifdefstring{\jkureport@doctype}{thesis}{%
         \ifdefstring{\jkureport@docsubtype}{seminar}{%
@@ -1977,7 +1982,14 @@
             \jkureport@insertsubmissiondate%
         }%
     }{%
-        \protect\@date%
+		\expandafter\jkureport@ifisodate\expandafter{\@date}{%
+			\begingroup%
+			\edef\@tmp{\noexpand\DTMsavedate{jkureport@docdate}{\@date}}\@tmp%
+			\DTMusedate{jkureport@docdate}%
+			\endgroup%
+		}{%
+			\protect\@date%
+		}%
     }%
 }
 \newcommand{\jkureport@insertplace}{Linz}%


### PR DESCRIPTION
Resolves #18 

For non-thesis types, if a date in the form YYYY-MM-DD (ISO date) is given, this change now tries to parse the date and prints it in the language-specific (localized) format (just as `\today` would do for the current date). Other strings will continue to be used as-is. To print an ISO date as-is, you could now wrap it into curly braces, e.g. `\date{{2024-12-20}}` to avoid automatic parsing.